### PR TITLE
Normalize the rotation before syncing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ serialize = ["bevy/serialize", "trackball/serde"]
 c11-orbit = ["trackball/cc"]
 
 [dependencies]
-bevy = { version = "0.13.0", default-features = false, features = ["bevy_render"] }
+bevy = { version = "0.13.0", default-features = false, features = ["bevy_render", "debug_glam_assert"] }
 bevy_egui = { version = "0.25.0", default-features = false, features = ["render"], optional = true }
 trackball = { version = "0.12.0", features = ["glam"] }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -138,7 +138,7 @@ pub fn trackball_camera(
 				.unwrap_or(trackball.frame);
 			let view = trackball.old_frame.view();
 			transform.translation = view.translation.into();
-			transform.rotation = view.rotation.into();
+			transform.rotation = view.rotation.normalize().into();
 		}
 		let new_scope = trackball.scope != trackball.old_scope;
 		let new_max = max != trackball.old_max;


### PR DESCRIPTION
After enabling the new feature `debug_glam_assert` in Bevy (which is forwarded to `glam`), my program panics when I rotate with the trackball. I traced it back to the syncing with the Bevy transform.